### PR TITLE
Allow multiple filters selection in Jobs page

### DIFF
--- a/app/views/solid_queue_dashboard/jobs/_filters.html.erb
+++ b/app/views/solid_queue_dashboard/jobs/_filters.html.erb
@@ -1,5 +1,6 @@
 <%= form_with url: jobs_path, method: :get, class: "space-y-3" do |form| %>
   <div>
+    <%= hidden_field_tag :status, params[:status] if params[:status].present? %>
     <label class="label">Status</label>
     <div class="flex flex-wrap gap-1 mt-1">
       <% SolidQueueDashboard::Job::STATUSES.each do |status| %>
@@ -26,6 +27,7 @@
   </div>
 
   <div>
+    <%= hidden_field_tag :class_name, params[:class_name] if params[:class_name].present? %>
     <label class="label">Job Class</label>
     <div class="flex flex-wrap gap-1 mt-1">
       <% @job_class_names.each do |class_name| %>
@@ -52,6 +54,7 @@
 
   <% if @job_queue_names.size > 1 %>
     <div>
+      <%= hidden_field_tag :queue_name, params[:queue_name] if params[:queue_name].present? %>
       <label class="label">Queue</label>
       <div class="flex flex-wrap gap-1 mt-1">
         <% @job_queue_names.each do |queue_name| %>


### PR DESCRIPTION
### What I did

- Updated `app/views/solid_queue_dashboard/jobs/_filters.html.erb` partial to handle multiple filters selection. Now, we can combine **Status**, **Job Class** and **Queue** filters.

![image](https://github.com/user-attachments/assets/48544907-d789-4460-967b-8d7fd37879f0)

Closes #9 
