### PR TITLE
[FIX] readme file update for devise authenticate

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For example, if using Devise:
 
 ```ruby
 Rails.application.routes.draw do
-  authenticate :current_admin do
+  authenticate :admin do
     mount SolidQueueDashboard::Engine, at: "/solid-queue"
   end
 end


### PR DESCRIPTION
There's a typo in the docs. So if you follow up Devise and generate a Devise "admin" model, then the authenticate is not `current_admin` but `admin`.

```diff
Rails.application.routes.draw do
- authenticate :current_admin do
+ authenticate :admin do
+  mount SolidQueueDashboard::Engine, at: "/solid-queue"
  end
end
```

At least "this works on my machine™". :)