### PR TITLE
Don't fail showing failed jobs without a backtrace

### DIFF
--- a/app/views/solid_queue_dashboard/jobs/show.html.erb
+++ b/app/views/solid_queue_dashboard/jobs/show.html.erb
@@ -145,8 +145,8 @@
         <%= @job.error_message %>
       </h4>
 
-      <% backtrace = Rails.backtrace_cleaner.clean(@job.failed_execution.error["backtrace"]) %>
-      <% if backtrace.any? %>
+      <% backtrace = Rails.backtrace_cleaner.clean(@job.failed_execution.error["backtrace"]) if @job.failed_execution.error["backtrace"]%>
+      <% if backtrace&.any? %>
         <ul class="list-decimal marker:text-sm marker:text-muted-foreground mt-1 ml-8 space-y-1">
           <% backtrace.each do |line| %>
             <li class="font-mono"><%= line %></li>


### PR DESCRIPTION
Sometimes jobs fail due to crashes, unhandled signals, etc., and viewing those would fail because of a missing backtrace.